### PR TITLE
Adding target LLVM_STRIP on 'bpftool' make

### DIFF
--- a/artifact/docker/Dockerfile
+++ b/artifact/docker/Dockerfile
@@ -76,7 +76,7 @@ RUN apt-get update && apt-get install -y linux-tools-$(uname -r) || \
     (cd /tmp && \
     git clone --recurse-submodules https://github.com/libbpf/bpftool.git && \
     cd bpftool/src && \
-    make install && \
+    make install LLVM_STRIP=llvm-strip-16 && \
     rm -rf /tmp/bpftool)
 
 # Clone the Honey Potion repository


### PR DESCRIPTION
This pull request fixes the issue when executing the command 

```bash
docker build -t docker-artifact -f Dockerfile .
```
to create the container images for running the experiments. 

The issue occurs when lbpf-tool tries to execute the `llvm-strip` command, which does not exist. The correct command for LLVM version 16 is `llvm-strip-16`

The image with the error is shown below:

![err1](https://github.com/user-attachments/assets/69c6cd44-0dc2-42cb-b6fa-dc4e42cdbad2)

